### PR TITLE
Convert GameCube isos to NKIT

### DIFF
--- a/TeconMoon's WiiVC Injector/Form1.cs
+++ b/TeconMoon's WiiVC Injector/Form1.cs
@@ -2114,40 +2114,30 @@ namespace TeconMoon_s_WiiVC_Injector
 
                 if (FlagNKIT)
                 {
-                    if (Directory.Exists(TempToolsPath + "NKIT\\Processed\\Temp"))
-                    {
-                        Directory.Delete(TempToolsPath + "NKIT\\Processed\\Temp", true);
-                    }
-                    BuildStatus.Text = "Unscrubbing game for NFS Conversion...";
-                    BuildStatus.Refresh();
-                    LauncherExeFile = TempToolsPath + "NKIT\\ConvertToISO.exe";
-                    LauncherExeArgs = "\"" + OpenGame.FileName;
-                    LaunchProgram(); // CONVERT TO ISO
-                    File.Move(Directory.GetFiles(TempToolsPath + "NKIT\\Processed\\GameCube_MatchFail", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\game.iso");
+                    File.Copy(OpenGame.FileName, TempSourcePath + "TEMPISOBASE\\files\\game.iso");
                 }
                 else
                 {
-                    File.Copy(OpenGame.FileName, TempSourcePath + "TEMPISOBASE\\files\\game.iso");
+                    BuildStatus.Text = "Scrubbing game for NFS Conversion...";
+                    BuildStatus.Refresh();
+                    LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
+                    LauncherExeArgs = "\"" + OpenGame.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\files\\game.iso\"";
+                    LaunchProgram(); // CONVERT TO NKIT
                 }
 
                 if (FlagGC2Specified)
                 {
                     if (FlagNKIT)
                     {
-                        if (Directory.Exists(TempToolsPath + "NKIT\\Processed\\Temp"))
-                        {
-                            Directory.Delete(TempToolsPath + "NKIT\\Processed\\Temp", true);
-                        }
-                        BuildStatus.Text = "Unscrubbing second disc for NFS Conversion...";
-                        BuildStatus.Refresh();
-                        LauncherExeFile = TempToolsPath + "NKIT\\ConvertToISO.exe";
-                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\"";
-                        LaunchProgram(); // CONVERT DISC 2 TO ISO
-                        File.Move(Directory.GetFiles(TempToolsPath + "NKIT\\Processed\\GameCube_MatchFail", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
+                        File.Copy(OpenGC2.FileName, TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
                     }
                     else
                     {
-                        File.Copy(OpenGC2.FileName, TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
+                        BuildStatus.Text = "Scrubbing second disc for NFS Conversion...";
+                        BuildStatus.Refresh();
+                        LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
+                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\files\\disc2.iso\"";
+                        LaunchProgram(); // CONVERT DISC 2 TO NKIT
                     }
                 }
                 LauncherExeFile = TempToolsPath + "WIT\\wit.exe";

--- a/TeconMoon's WiiVC Injector/Form1.cs
+++ b/TeconMoon's WiiVC Injector/Form1.cs
@@ -2120,10 +2120,10 @@ namespace TeconMoon_s_WiiVC_Injector
                 {
                     BuildStatus.Text = "Scrubbing game for NFS Conversion...";
                     BuildStatus.Refresh();
-                    LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
-                    LauncherExeArgs = "\"" + OpenGame.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\\"";
+                    LauncherExeFile = TempToolsPath + "NKIT\\ConvertToNKit.exe";
+                    LauncherExeArgs = "\"" + OpenGame.FileName + "\"";
                     LaunchProgram(); // CONVERT TO NKIT
-                    File.Move(Directory.GetFiles(TempSourcePath + "TEMPISOBASE\\", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\game.iso");
+                    File.Move(Directory.GetFiles(TempToolsPath + "NKIT\\Processed\\GameCube_MatchFail", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\game.iso");
                 }
 
                 if (FlagGC2Specified)
@@ -2136,10 +2136,10 @@ namespace TeconMoon_s_WiiVC_Injector
                     {
                         BuildStatus.Text = "Scrubbing second disc for NFS Conversion...";
                         BuildStatus.Refresh();
-                        LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
-                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\\"";
+                        LauncherExeFile = TempToolsPath + "NKIT\\ConvertToNKit.exe";
+                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\"";
                         LaunchProgram(); // CONVERT DISC 2 TO NKIT
-                        File.Move(Directory.GetFiles(TempSourcePath + "TEMPISOBASE\\", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
+                        File.Move(Directory.GetFiles(TempToolsPath + "NKIT\\Processed\\GameCube_MatchFail", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
                     }
                 }
                 LauncherExeFile = TempToolsPath + "WIT\\wit.exe";

--- a/TeconMoon's WiiVC Injector/Form1.cs
+++ b/TeconMoon's WiiVC Injector/Form1.cs
@@ -2121,8 +2121,9 @@ namespace TeconMoon_s_WiiVC_Injector
                     BuildStatus.Text = "Scrubbing game for NFS Conversion...";
                     BuildStatus.Refresh();
                     LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
-                    LauncherExeArgs = "\"" + OpenGame.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\files\\game.iso\"";
+                    LauncherExeArgs = "\"" + OpenGame.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\\"";
                     LaunchProgram(); // CONVERT TO NKIT
+                    File.Move(Directory.GetFiles(TempSourcePath + "TEMPISOBASE\\", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\game.iso");
                 }
 
                 if (FlagGC2Specified)
@@ -2136,8 +2137,9 @@ namespace TeconMoon_s_WiiVC_Injector
                         BuildStatus.Text = "Scrubbing second disc for NFS Conversion...";
                         BuildStatus.Refresh();
                         LauncherExeFile = TempToolsPath + "NKIT\\gcit.exe";
-                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\files\\disc2.iso\"";
+                        LauncherExeArgs = "\"" + OpenGC2.FileName + "\" -q -d \"" + TempSourcePath + "TEMPISOBASE\\\"";
                         LaunchProgram(); // CONVERT DISC 2 TO NKIT
+                        File.Move(Directory.GetFiles(TempSourcePath + "TEMPISOBASE\\", "*.iso")[0], TempSourcePath + "TEMPISOBASE\\files\\disc2.iso");
                     }
                 }
                 LauncherExeFile = TempToolsPath + "WIT\\wit.exe";


### PR DESCRIPTION
Convert all gamecube isos to NKIT to save as much space as possible.

This superseeds https://github.com/piratesephiroth/TeconmoonWiiVCInjector/pull/35

https://github.com/piratesephiroth/TeconmoonWiiVCInjector/pull/36